### PR TITLE
Upgrade `unicode-width` to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 exclude = ["fuzz", ".gitignore", ".github", "scripts"]
 
 [dependencies]
-unicode-width = "0.1.9"
+unicode-width = "0.2.0"
 
 [features]
 default = ["native", "alloc", "std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,6 +478,7 @@ mod tests {
         (r#"can'"t"#, r#"'can'\''"t'"#),
         (r#"can'$t"#, r#"'can'\''$t'"#),
         ("foo\nb\ta\r\\\0`r", r#"$'foo\nb\ta\r\\\x00`r'"#),
+        ("trailing newline\n", r#"$'trailing newline\n'"#),
         ("foo\x02", r#"$'foo\x02'"#),
         (r#"'$''"#, r#"\''$'\'\'"#),
     ];


### PR DESCRIPTION
`unicode-width` has to bundle character tables, so it's quite heavy (1.5MB total size).  They've recently bumped their version to 0.2, which caused `unicode-width` to be duplicated between in projects with a lot of dependencies (like [Nushell](https://github.com/nushell/nushell)).

This commit bumps `unicode-width` version to 0.2 to address that.  The main breaking change between 0.1 and 0.2 is that newline now has width of 1.  But that doesn't affect `os_display`, since it escapes the newlines.